### PR TITLE
chore(copilot): move agents to .github/agents and ignore claude local…

### DIFF
--- a/.github/agents/dev-loop.agent.md
+++ b/.github/agents/dev-loop.agent.md
@@ -1,4 +1,5 @@
 ---
+name: dev-loop
 description: Dev-loop orchestrator. Coordinates explorer, developer, and reviewer agents in an iterative development cycle. Runs up to 5 developer-reviewer iterations, stopping early when the reviewer scores the implementation 8/10 or higher.
 ---
 

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -1,4 +1,5 @@
 ---
+name: developer
 description: Senior developer agent. Implements features and bug fixes following project conventions, validates with typecheck and tests, and accepts context from explorer and feedback from reviewer.
 ---
 

--- a/.github/agents/explorer.agent.md
+++ b/.github/agents/explorer.agent.md
@@ -1,4 +1,5 @@
 ---
+name: explorer
 description: Read-only codebase explorer. Maps affected files, existing patterns, and reuse candidates to inform implementation before any code is written.
 ---
 

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,4 +1,5 @@
 ---
+name: reviewer
 description: Outcome-focused code reviewer. Scores implementation 1-10 against the original problem statement. Prioritizes whether the problem is actually solved over surface-level acceptance criteria mapping.
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ Thumbs.db
 .vscode/
 .idea/
 
+# Claude Code (per-developer overrides)
+.claude/settings.local.json
+
 # npm lock file (project uses pnpm)
 package-lock.json


### PR DESCRIPTION
… settings

Align Copilot custom agents with GitHub's published spec (docs.github.com/en/copilot/.../create-custom-agents):

- Move .github/copilot/agents/*.agent.md to .github/agents/*.agent.md so the cloud-agent loader actually discovers them.
- Add explicit `name:` frontmatter to each agent (was relying on the filename default; explicit name decouples display name from path).
- Gitignore .claude/settings.local.json so per-developer Claude Code overrides (sandbox allowlists for the .bare worktree layout, etc.) stay local.