### PR TITLE
ci(copilot): warm up Copilot cloud agent environment

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,45 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  # Job name MUST be `copilot-setup-steps` — GitHub uses this name as a discovery
+  # contract to run these steps before the Copilot cloud agent boots.
+  copilot-setup-steps:
+    name: Warm up Copilot agent environment
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      TURBO_TELEMETRY_DISABLED: 1
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: turbo-${{ runner.os }}-


### PR DESCRIPTION
## Summary
- Add `.github/workflows/copilot-setup-steps.yml` with the GitHub-mandated `copilot-setup-steps` job name so the Copilot cloud agent boots with `node_modules/` already installed.
- Mirror `ci.yml` versions (pnpm 10.33.0, Node 22) and cache keys so warm-ups reuse the pnpm store and Turbo cache CI populates on `main`.
- Triggers: `workflow_dispatch` plus path-scoped `pull_request` / `push` on the workflow file itself, so we can validate edits without burning CI minutes on every PR.

Reference: [Customize the agent environment](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/customize-the-agent-environment)

## Test plan
- [ ] Run *Actions → Copilot Setup Steps → Run workflow* on this branch and confirm the job name in the run UI is `copilot-setup-steps`
- [ ] Confirm "Install dependencies" succeeds and the post-step pnpm cache save runs
- [ ] Re-run on the same lockfile and confirm pnpm + Turbo cache steps report `Cache hit`
- [ ] Assign `@dev-loop` to a small test issue and verify the agent's bootstrap log shows `node_modules/` already present (no cold install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)