### PR TITLE
docs(readme,dashboard): disclose hybrid scoring (23 GitHub + 24 LLM-inferred)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,33 @@ See [`SPEC.md`](SPEC.md) for the full question set, scoring rubrics, and evidenc
 
 ---
 
+## How Scoring Works
+
+The scorecard is **hybrid by design**. Some questions can be answered straight from
+GitHub data (file presence, commit activity, CI configs, branch protection, etc.).
+Others — like _"do you have a centralized AI gateway?"_ or _"is your usage policy
+enforced?"_ — can't be settled by repo scanning alone, so the tool reads the relevant
+files and asks an LLM (Anthropic Claude) to make a judgment based on what it finds.
+
+Of the 47 questions:
+
+- **23 are answered by deterministic GitHub data collectors** — file scans, Actions
+  workflow analysis, PR/commit metadata, secret scanning settings.
+- **24 are answered by AI inference** when `--ai-inference` is enabled (otherwise they
+  score 0 with no evidence).
+
+AI-inferred answers are LLM judgments and are **less certain than direct measurements
+by design**. The scoring engine clamps inferred-question confidence to the **0.3–0.7
+range** (see `packages/adapters/src/ai-inference/index.ts`) so they cannot drown out
+high-confidence GitHub signals when computing the overall confidence score.
+
+Every score ships with its `evidence.source` (e.g. `github:repos`, `github:actions`,
+`ai-inference`). The dashboard surfaces this on each question so you can tell at a
+glance whether a number came from a measurement or a model. See [`SPEC.md`](SPEC.md)
+for the per-question evidence mapping.
+
+---
+
 ## Maturity Tiers
 
 | Tier    | Score | Label               |

--- a/packages/dashboard/app/results/page.tsx
+++ b/packages/dashboard/app/results/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import type { ScorecardResult } from "@ai-scorecard/core";
 import { encodeResults, decodeResults } from "@ai-scorecard/core";
 import { ScoreCard } from "@/components/ScoreCard";
+import { DataSourceBadge } from "@/components/ScoreCard/DataSourceBadge";
 import { Button } from "@/components/ui/Button";
 import { LoadingSpinner } from "@/components/ui/LoadingSpinner";
 import { ShareButton } from "@/components/Share/ShareButton";
@@ -130,6 +131,14 @@ function ResultsPageContent() {
           </Button>
         </div>
         {pdfError && <p className="text-sm text-red-400">{pdfError}</p>}
+      </div>
+
+      <div className="mb-6 flex flex-wrap items-center gap-2 rounded-lg border border-slate-700/60 bg-slate-900/40 px-3 py-2 text-xs text-slate-400">
+        <span>Each question shows where its score came from:</span>
+        <DataSourceBadge source="github" />
+        <span>= deterministic GitHub data;</span>
+        <DataSourceBadge source="ai-inference" />
+        <span>= LLM judgment (lower confidence by design).</span>
       </div>
 
       <ScoreCard result={result} />

--- a/packages/dashboard/components/ScoreCard/DataSourceBadge.tsx
+++ b/packages/dashboard/components/ScoreCard/DataSourceBadge.tsx
@@ -1,0 +1,71 @@
+import type { Evidence } from "@ai-scorecard/core";
+
+export type DataSourceKind = "github" | "ai-inference" | "other";
+
+/**
+ * Classify an evidence source string into a coarse "where did this come from?" bucket.
+ * Anything starting with `github:` is a deterministic GitHub data collector; anything
+ * starting with `ai-inference` is an LLM judgment with confidence clamped to 0.3-0.7.
+ */
+export function classifyEvidenceSource(source: string): DataSourceKind {
+  if (source.startsWith("github:")) return "github";
+  if (source.startsWith("ai-inference")) return "ai-inference";
+  return "other";
+}
+
+/**
+ * Pick the dominant source for a question — `ai-inference` wins if any evidence is
+ * AI-inferred (so users see the lower-confidence label), otherwise `github`, otherwise
+ * "other". Returns null when there is no evidence at all.
+ */
+export function dominantSource(evidence: Evidence[]): DataSourceKind | null {
+  if (evidence.length === 0) return null;
+  let sawGithub = false;
+  let sawOther = false;
+  for (const e of evidence) {
+    const kind = classifyEvidenceSource(e.source);
+    if (kind === "ai-inference") return "ai-inference";
+    if (kind === "github") sawGithub = true;
+    else sawOther = true;
+  }
+  if (sawGithub) return "github";
+  if (sawOther) return "other";
+  return null;
+}
+
+interface DataSourceBadgeProps {
+  source: DataSourceKind;
+}
+
+export function DataSourceBadge({ source }: DataSourceBadgeProps) {
+  if (source === "github") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-slate-700/60 px-2 py-0.5 text-xs font-medium text-slate-200"
+        title="Answered by a deterministic GitHub data collector"
+        aria-label="Data source: GitHub data"
+      >
+        Data Source: github
+      </span>
+    );
+  }
+  if (source === "ai-inference") {
+    return (
+      <span
+        className="inline-flex items-center gap-1 rounded-full bg-amber-900/40 px-2 py-0.5 text-xs font-medium text-amber-300 ring-1 ring-amber-500/30"
+        title="Answered by an LLM reading repo contents — confidence clamped to 0.3-0.7"
+        aria-label="Data source: AI inference"
+      >
+        Data Source: ai-inference
+      </span>
+    );
+  }
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full bg-slate-800/60 px-2 py-0.5 text-xs font-medium text-slate-400"
+      aria-label={`Data source: ${source}`}
+    >
+      Data Source: {source}
+    </span>
+  );
+}

--- a/packages/dashboard/components/ScoreCard/QuestionRow.tsx
+++ b/packages/dashboard/components/ScoreCard/QuestionRow.tsx
@@ -1,5 +1,6 @@
 import type { Question, QuestionScore } from "@ai-scorecard/core";
 import { ConfidenceBadge } from "./ConfidenceBadge";
+import { DataSourceBadge, dominantSource } from "./DataSourceBadge";
 
 interface QuestionRowProps {
   question: Question;
@@ -23,6 +24,7 @@ export function QuestionRow({ question, questionScore }: QuestionRowProps) {
   const rubricText = question.rubric[scoreLevel];
 
   const evidenceSummaries = questionScore.evidence.filter((e) => e.summary).slice(0, 2);
+  const sourceKind = dominantSource(questionScore.evidence);
 
   return (
     <div className="border-t border-slate-700/60 py-3">
@@ -41,6 +43,7 @@ export function QuestionRow({ question, questionScore }: QuestionRowProps) {
           {scoreLevel}/2 — {scoreLabels[scoreLevel]}
         </span>
         <ConfidenceBadge confidence={questionScore.confidence} />
+        {sourceKind && <DataSourceBadge source={sourceKind} />}
       </div>
       {rubricText && <p className="mt-1 text-xs text-slate-400 italic">"{rubricText}"</p>}
       {evidenceSummaries.length > 0 && (


### PR DESCRIPTION
## Summary

- Adds a "How Scoring Works" section to the README explaining the hybrid model: **23/47 questions** are answered by deterministic GitHub data collectors and **24/47** are answered by LLM inference (with confidence clamped to `[0.3, 0.7]` per `packages/adapters/src/ai-inference/index.ts`).
- Adds per-question **Data Source badges** (`Data Source: github` / `Data Source: ai-inference`) on the dashboard results page, driven entirely off `evidence.source`. The inference badge is rendered with an amber tint so users can tell measurements from model judgments at a glance.
- Adds a one-line legend at the top of the results page explaining the two badge types.

The 23/24 split was cross-checked against `ANALYSIS_QUESTION_MAP` in the AI inference module — the original audit said 22, but the code includes Q36 and Q41 (D7 agent-analysis) so the real count is 24. The README and PR title reflect the code, not the audit.

## Test plan

- [x] `pnpm typecheck` — green (8 tasks)
- [x] `pnpm lint` — green (no warnings or errors)
- [x] `pnpm test` — green (24/24 adapter tests)
- [x] `pnpm format` — green (all files unchanged)
- [x] `pnpm --filter @ai-scorecard/dashboard build` — green (Next.js production build)
- [ ] Visual sanity check of the badges on the results page (pending — `pnpm dev` not exercised in this run; component logic is straightforward and TS-checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)