### PR TITLE
feat(core): zod validation on Evidence + SignalResult; CLI e2e smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,6 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: CLI end-to-end smoke test
+        run: pnpm --filter @ai-scorecard/cli test

--- a/packages/adapters/src/github/collectors/actions.ts
+++ b/packages/adapters/src/github/collectors/actions.ts
@@ -1,28 +1,15 @@
 import type { Octokit } from "@octokit/rest";
 import type { SignalResult, Evidence } from "@ai-scorecard/core";
 import type { RepoInfo } from "./repo-scan.js";
-import {
-  createCollectorContext,
-  type CollectorContext,
-  type CollectorOutcome,
-} from "../collector-error.js";
-
-function statusOf(err: unknown): number | undefined {
-  if (err === null || typeof err !== "object") return undefined;
-  const s = (err as { status?: unknown }).status;
-  return typeof s === "number" ? s : undefined;
-}
 
 /**
- * Fetch workflow runs for a repo over the last 30 days. Per-repo 404s are
- * tolerated silently; auth/rate-limit/unexpected errors are reported via `ctx`.
+ * Fetch workflow runs for a repo over the last 30 days.
  */
 async function fetchWorkflowRuns(
   octokit: Octokit,
   owner: string,
   repo: string,
-  since: Date,
-  ctx: CollectorContext
+  since: Date
 ): Promise<
   {
     id: number;
@@ -51,18 +38,19 @@ async function fetchWorkflowRuns(
       runStartedAt: run.run_started_at ? new Date(run.run_started_at) : null,
       name: run.name ?? null,
     }));
-  } catch (err) {
-    if (statusOf(err) !== 404) ctx.report(err);
+  } catch {
     return [];
   }
 }
 
-/** Q14 — CI/CD pipeline scaling */
+/**
+ * Q14 — CI/CD pipeline scaling
+ * Analyzes workflow run times, queue times, and failure rates.
+ */
 export async function collectPipelineScalingSignal(
   octokit: Octokit,
   repos: RepoInfo[]
-): Promise<CollectorOutcome<SignalResult>> {
-  const ctx = createCollectorContext("github:actions:q14-pipeline-scaling");
+): Promise<SignalResult> {
   const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   let totalRuns = 0;
   let failedRuns = 0;
@@ -70,7 +58,7 @@ export async function collectPipelineScalingSignal(
 
   for (const repo of repos) {
     const owner = repo.fullName.split("/")[0] ?? "";
-    const runs = await fetchWorkflowRuns(octokit, owner, repo.name, since, ctx);
+    const runs = await fetchWorkflowRuns(octokit, owner, repo.name, since);
     totalRuns += runs.length;
 
     for (const run of runs) {
@@ -80,6 +68,7 @@ export async function collectPipelineScalingSignal(
       if (run.runStartedAt !== null && run.conclusion !== null) {
         const durationSec = (run.updatedAt.getTime() - run.runStartedAt.getTime()) / 1000;
         if (durationSec > 0 && durationSec < 7200) {
+          // sanity check < 2hrs
           durationsSec.push(durationSec);
         }
       }
@@ -121,36 +110,36 @@ export async function collectPipelineScalingSignal(
   }
 
   return {
-    result: {
-      signalId: ctx.signalId,
-      questionId: "D3-Q14",
-      score,
-      evidence,
-      confidence: 0.7,
-    },
-    errors: ctx.errors(),
+    signalId: "github:actions:q14-pipeline-scaling",
+    questionId: "D3-Q14",
+    score,
+    evidence,
+    confidence: 0.7,
   };
 }
 
-/** Q17 — Test quality / flaky test rate */
+/**
+ * Q17 — Test quality / flaky test rate
+ * Analyzes test workflow results for flaky re-runs.
+ */
 export async function collectTestQualitySignal(
   octokit: Octokit,
   repos: RepoInfo[]
-): Promise<CollectorOutcome<SignalResult>> {
-  const ctx = createCollectorContext("github:actions:q17-test-quality");
+): Promise<SignalResult> {
   const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   let testWorkflowsFound = 0;
   let rerunWorkflows = 0;
 
   for (const repo of repos) {
     const owner = repo.fullName.split("/")[0] ?? "";
-    const runs = await fetchWorkflowRuns(octokit, owner, repo.name, since, ctx);
+    const runs = await fetchWorkflowRuns(octokit, owner, repo.name, since);
 
     const testRuns = runs.filter(
       (r) => r.name !== null && /test|spec|coverage|jest|vitest|pytest|mocha/i.test(r.name)
     );
     testWorkflowsFound += testRuns.length;
 
+    // Check for re-runs (same workflow name running multiple times in short succession)
     const runsByName = new Map<string, number[]>();
     for (const run of testRuns) {
       if (run.name) {
@@ -161,6 +150,7 @@ export async function collectTestQualitySignal(
     }
 
     for (const [, times] of runsByName) {
+      // If workflow ran more than expected (> 1.5 runs per day on average), suggest flakiness
       const daysCovered = 30;
       const runsPerDay = times.length / daysCovered;
       if (runsPerDay > 1.5) {
@@ -191,13 +181,10 @@ export async function collectTestQualitySignal(
   else if (testWorkflowsFound > 0) score = 1;
 
   return {
-    result: {
-      signalId: ctx.signalId,
-      questionId: "D3-Q17",
-      score,
-      evidence,
-      confidence: 0.4,
-    },
-    errors: ctx.errors(),
+    signalId: "github:actions:q17-test-quality",
+    questionId: "D3-Q17",
+    score,
+    evidence,
+    confidence: 0.4,
   };
 }

--- a/packages/adapters/src/github/collectors/actions.ts
+++ b/packages/adapters/src/github/collectors/actions.ts
@@ -1,15 +1,28 @@
 import type { Octokit } from "@octokit/rest";
 import type { SignalResult, Evidence } from "@ai-scorecard/core";
 import type { RepoInfo } from "./repo-scan.js";
+import {
+  createCollectorContext,
+  type CollectorContext,
+  type CollectorOutcome,
+} from "../collector-error.js";
+
+function statusOf(err: unknown): number | undefined {
+  if (err === null || typeof err !== "object") return undefined;
+  const s = (err as { status?: unknown }).status;
+  return typeof s === "number" ? s : undefined;
+}
 
 /**
- * Fetch workflow runs for a repo over the last 30 days.
+ * Fetch workflow runs for a repo over the last 30 days. Per-repo 404s are
+ * tolerated silently; auth/rate-limit/unexpected errors are reported via `ctx`.
  */
 async function fetchWorkflowRuns(
   octokit: Octokit,
   owner: string,
   repo: string,
-  since: Date
+  since: Date,
+  ctx: CollectorContext
 ): Promise<
   {
     id: number;
@@ -38,19 +51,18 @@ async function fetchWorkflowRuns(
       runStartedAt: run.run_started_at ? new Date(run.run_started_at) : null,
       name: run.name ?? null,
     }));
-  } catch {
+  } catch (err) {
+    if (statusOf(err) !== 404) ctx.report(err);
     return [];
   }
 }
 
-/**
- * Q14 — CI/CD pipeline scaling
- * Analyzes workflow run times, queue times, and failure rates.
- */
+/** Q14 — CI/CD pipeline scaling */
 export async function collectPipelineScalingSignal(
   octokit: Octokit,
   repos: RepoInfo[]
-): Promise<SignalResult> {
+): Promise<CollectorOutcome<SignalResult>> {
+  const ctx = createCollectorContext("github:actions:q14-pipeline-scaling");
   const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   let totalRuns = 0;
   let failedRuns = 0;
@@ -58,7 +70,7 @@ export async function collectPipelineScalingSignal(
 
   for (const repo of repos) {
     const owner = repo.fullName.split("/")[0] ?? "";
-    const runs = await fetchWorkflowRuns(octokit, owner, repo.name, since);
+    const runs = await fetchWorkflowRuns(octokit, owner, repo.name, since, ctx);
     totalRuns += runs.length;
 
     for (const run of runs) {
@@ -68,7 +80,6 @@ export async function collectPipelineScalingSignal(
       if (run.runStartedAt !== null && run.conclusion !== null) {
         const durationSec = (run.updatedAt.getTime() - run.runStartedAt.getTime()) / 1000;
         if (durationSec > 0 && durationSec < 7200) {
-          // sanity check < 2hrs
           durationsSec.push(durationSec);
         }
       }
@@ -110,36 +121,36 @@ export async function collectPipelineScalingSignal(
   }
 
   return {
-    signalId: "github:actions:q14-pipeline-scaling",
-    questionId: "D3-Q14",
-    score,
-    evidence,
-    confidence: 0.7,
+    result: {
+      signalId: ctx.signalId,
+      questionId: "D3-Q14",
+      score,
+      evidence,
+      confidence: 0.7,
+    },
+    errors: ctx.errors(),
   };
 }
 
-/**
- * Q17 — Test quality / flaky test rate
- * Analyzes test workflow results for flaky re-runs.
- */
+/** Q17 — Test quality / flaky test rate */
 export async function collectTestQualitySignal(
   octokit: Octokit,
   repos: RepoInfo[]
-): Promise<SignalResult> {
+): Promise<CollectorOutcome<SignalResult>> {
+  const ctx = createCollectorContext("github:actions:q17-test-quality");
   const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   let testWorkflowsFound = 0;
   let rerunWorkflows = 0;
 
   for (const repo of repos) {
     const owner = repo.fullName.split("/")[0] ?? "";
-    const runs = await fetchWorkflowRuns(octokit, owner, repo.name, since);
+    const runs = await fetchWorkflowRuns(octokit, owner, repo.name, since, ctx);
 
     const testRuns = runs.filter(
       (r) => r.name !== null && /test|spec|coverage|jest|vitest|pytest|mocha/i.test(r.name)
     );
     testWorkflowsFound += testRuns.length;
 
-    // Check for re-runs (same workflow name running multiple times in short succession)
     const runsByName = new Map<string, number[]>();
     for (const run of testRuns) {
       if (run.name) {
@@ -150,7 +161,6 @@ export async function collectTestQualitySignal(
     }
 
     for (const [, times] of runsByName) {
-      // If workflow ran more than expected (> 1.5 runs per day on average), suggest flakiness
       const daysCovered = 30;
       const runsPerDay = times.length / daysCovered;
       if (runsPerDay > 1.5) {
@@ -181,10 +191,13 @@ export async function collectTestQualitySignal(
   else if (testWorkflowsFound > 0) score = 1;
 
   return {
-    signalId: "github:actions:q17-test-quality",
-    questionId: "D3-Q17",
-    score,
-    evidence,
-    confidence: 0.4,
+    result: {
+      signalId: ctx.signalId,
+      questionId: "D3-Q17",
+      score,
+      evidence,
+      confidence: 0.4,
+    },
+    errors: ctx.errors(),
   };
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,8 @@
     "build": "tsc --project tsconfig.json",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "lint": "eslint src --ext .ts",
+    "pretest": "tsc --project tsconfig.json",
+    "test": "vitest run",
     "clean": "rm -rf dist"
   },
   "dependencies": {
@@ -29,6 +31,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "4.1.2"
   }
 }

--- a/packages/cli/test/assess-e2e.test.ts
+++ b/packages/cli/test/assess-e2e.test.ts
@@ -1,0 +1,162 @@
+/**
+ * End-to-end smoke test for the `assess` command.
+ *
+ * Locks the contract that a fully-mocked assess invocation returns a complete
+ * 8-dimension / 0–94 scorecard with a valid tier label. This is the regression
+ * net the home-page V1.0 → V1.1 mismatch (commit 8972acf) slipped through —
+ * the previous CI ran unit tests but never wired the full CLI flow end-to-end.
+ *
+ * External dependencies (Octokit + Anthropic SDK) are stubbed via vi.mock so
+ * the test runs hermetically with no network access.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { SignalResult } from "@ai-scorecard/core";
+
+const fakeGithubSignals: SignalResult[] = [
+  {
+    signalId: "github:repos",
+    questionId: "D1-Q1",
+    score: 2,
+    evidence: [
+      {
+        source: "github:repos",
+        data: { count: 12 },
+        summary: "Found 12 active repositories under the org",
+      },
+    ],
+    confidence: 1,
+  },
+  {
+    signalId: "github:actions",
+    questionId: "D3-Q11",
+    score: 1,
+    evidence: [
+      {
+        source: "github:actions",
+        data: { workflows: 4 },
+        summary: "Detected 4 GitHub Actions workflows",
+      },
+    ],
+    confidence: 0.9,
+  },
+];
+
+const fakeAiSignals: SignalResult[] = [
+  {
+    signalId: "ai:inference",
+    questionId: "D6-Q26",
+    score: 1,
+    evidence: [
+      {
+        source: "ai-inference",
+        data: { rationale: "fixture" },
+        summary: "AI inferred partial documentation coverage",
+      },
+    ],
+    confidence: 0.5,
+  },
+];
+
+vi.mock("@ai-scorecard/adapters", () => {
+  class GitHubAdapter {
+    name = "github";
+    signals = [];
+    async connect(): Promise<void> {
+      /* fixture — no-op */
+    }
+    async collect(): Promise<SignalResult[]> {
+      return fakeGithubSignals;
+    }
+  }
+
+  class AIInferenceEngine {
+    constructor(_config: unknown) {
+      void _config;
+    }
+    async analyze(_bundle: unknown): Promise<SignalResult[]> {
+      void _bundle;
+      return fakeAiSignals;
+    }
+  }
+
+  return { GitHubAdapter, AIInferenceEngine };
+});
+
+const VALID_TIERS = ["AI-Curious", "AI-Experimenting", "AI-Scaling", "AI-Native"] as const;
+
+describe("assess command end-to-end", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit called with ${code ?? 0}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+    vi.resetModules();
+  });
+
+  it("dry-run exits cleanly without external calls", async () => {
+    const { runAssess } = await import("../src/commands/assess.js");
+    await runAssess({
+      githubOrg: "acme",
+      githubToken: "fake-token",
+      output: "json",
+      dryRun: true,
+    });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("full flow with mocked adapters produces an 8-dimension scorecard", async () => {
+    const { runAssess } = await import("../src/commands/assess.js");
+
+    await runAssess({
+      githubOrg: "acme",
+      githubToken: "fake-token",
+      aiInference: true,
+      anthropicKey: "fake-anthropic-key",
+      output: "json",
+    });
+
+    expect(exitSpy).not.toHaveBeenCalled();
+
+    const jsonCall = logSpy.mock.calls.find((args) => {
+      const first = args[0];
+      return typeof first === "string" && first.trim().startsWith("{");
+    });
+    expect(jsonCall, "expected JSON scorecard on stdout").toBeDefined();
+
+    const result = JSON.parse(jsonCall![0] as string);
+
+    expect(result.dimensions).toHaveLength(8);
+    expect(result.totalScore).toBeGreaterThanOrEqual(0);
+    expect(result.totalScore).toBeLessThanOrEqual(94);
+    expect(result.maxScore).toBe(94);
+    expect(VALID_TIERS).toContain(result.tier.label);
+    expect(typeof result.overallConfidence).toBe("number");
+    expect(result.overallConfidence).toBeGreaterThanOrEqual(0);
+    expect(result.overallConfidence).toBeLessThanOrEqual(1);
+    expect(result.metadata.adapterName).toBe("github");
+    expect(result.metadata.target).toBe("org:acme");
+  });
+
+  it("missing required options exits with non-zero code", async () => {
+    const { runAssess } = await import("../src/commands/assess.js");
+
+    await expect(
+      runAssess({
+        // no githubOrg, no githubToken
+        output: "json",
+      })
+    ).rejects.toThrow(/process\.exit called with 1/);
+  });
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    environment: "node",
+    testTimeout: 10000,
+  },
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,5 +21,8 @@
   "devDependencies": {
     "@types/node": "^25.5.2",
     "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
   }
 }

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1,6 +1,9 @@
+import { z } from "zod";
 import { dimensions } from "./dimensions.js";
 import { questions } from "./questions.js";
 import { tiers } from "./tiers.js";
+import { ScoringValidationError } from "./errors.js";
+import { SignalResultSchema } from "./types/adapter.js";
 import type {
   DimensionScore,
   QuestionScore,
@@ -8,21 +11,35 @@ import type {
   SignalResult,
 } from "./types/index.js";
 
+const SignalResultsInputSchema = z.array(SignalResultSchema);
+
 /**
  * Takes raw signal results from adapters and computes the full scorecard.
  *
  * When multiple signals map to the same question (e.g., GitHub adapter + AI inference
  * both score Q7), use the signal with the highest confidence. If confidence is equal,
  * use the higher score (benefit of the doubt).
+ *
+ * @throws {ScoringValidationError} if any signal in `signals` does not match
+ *   {@link SignalResultSchema} — for example, a missing `evidence.summary`,
+ *   `score` outside 0/1/2, or `confidence` outside [0, 1]. This is a hard
+ *   boundary check: AI-inferred or adapter-supplied evidence must conform
+ *   before any score is computed.
  */
 export function computeScorecard(
   signals: SignalResult[],
   metadata: { adapterName: string; target: string },
   assessedAt: Date = new Date()
 ): ScorecardResult {
+  const parsed = SignalResultsInputSchema.safeParse(signals);
+  if (!parsed.success) {
+    throw new ScoringValidationError(parsed.error);
+  }
+  const validatedSignals = parsed.data;
+
   // 1. Deduplicate signals — keep highest confidence; break ties with higher score
   const dedupedSignals = new Map<string, SignalResult>();
-  for (const signal of signals) {
+  for (const signal of validatedSignals) {
     const existing = dedupedSignals.get(signal.questionId);
     if (
       !existing ||

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -17,8 +17,7 @@ export class ScoringValidationError extends Error {
         return `${path}: ${issue.message}`;
       })
       .join("; ");
-    const overflow =
-      zodError.issues.length > 5 ? ` (+${zodError.issues.length - 5} more)` : "";
+    const overflow = zodError.issues.length > 5 ? ` (+${zodError.issues.length - 5} more)` : "";
     super(`${prefix}: ${summary}${overflow}`);
     this.name = "ScoringValidationError";
     this.issues = zodError.issues;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,26 @@
+import type { ZodError } from "zod";
+
+/**
+ * Thrown when {@link computeScorecard} receives signal results that do not
+ * conform to {@link SignalResultSchema}. Carries the original Zod issues so
+ * callers (CLI, dashboard, integration tests) can surface field-level
+ * diagnostics without re-parsing the message.
+ */
+export class ScoringValidationError extends Error {
+  readonly issues: ZodError["issues"];
+
+  constructor(zodError: ZodError, prefix = "Invalid signal results") {
+    const summary = zodError.issues
+      .slice(0, 5)
+      .map((issue) => {
+        const path = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+        return `${path}: ${issue.message}`;
+      })
+      .join("; ");
+    const overflow =
+      zodError.issues.length > 5 ? ` (+${zodError.issues.length - 5} more)` : "";
+    super(`${prefix}: ${summary}${overflow}`);
+    this.name = "ScoringValidationError";
+    this.issues = zodError.issues;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,10 +31,12 @@ export type {
   Tier,
   ScorecardResult,
 } from "./types/index.js";
+export { EvidenceSchema, SignalResultSchema } from "./types/index.js";
 export { dimensions } from "./dimensions.js";
 export { questions } from "./questions.js";
 export { tiers } from "./tiers.js";
 export { computeScorecard } from "./engine.js";
+export { ScoringValidationError } from "./errors.js";
 export {
   getWeakestDimensions,
   getUnaddressedQuestions,

--- a/packages/core/src/types/adapter.ts
+++ b/packages/core/src/types/adapter.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 /** Configuration passed to an adapter to connect to a data source */
 export interface AdapterConfig {
   /** Adapter-specific configuration (e.g., GitHub token, org name) */
@@ -49,3 +51,26 @@ export interface Adapter {
   /** Collect all signals from the data source */
   collect(): Promise<SignalResult[]>;
 }
+
+/**
+ * Runtime schema for {@link Evidence}. Used at the engine boundary
+ * ({@link computeScorecard}) to reject malformed adapter or AI-inferred output
+ * before it can corrupt a score. Mirrors the {@link Evidence} interface.
+ */
+export const EvidenceSchema: z.ZodType<Evidence> = z.object({
+  source: z.string().min(1, "Evidence.source must be a non-empty string"),
+  data: z.unknown(),
+  summary: z.string().min(1, "Evidence.summary must be a non-empty string"),
+});
+
+/**
+ * Runtime schema for {@link SignalResult}. Enforces the score (0/1/2) and
+ * confidence ([0, 1]) invariants the scoring engine relies on.
+ */
+export const SignalResultSchema: z.ZodType<SignalResult> = z.object({
+  signalId: z.string().min(1, "SignalResult.signalId must be a non-empty string"),
+  questionId: z.string().min(1, "SignalResult.questionId must be a non-empty string"),
+  score: z.union([z.literal(0), z.literal(1), z.literal(2)]),
+  evidence: z.array(EvidenceSchema),
+  confidence: z.number().min(0).max(1),
+});

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,4 +1,5 @@
 export type { AdapterConfig, Signal, Evidence, SignalResult, Adapter } from "./adapter.js";
+export { EvidenceSchema, SignalResultSchema } from "./adapter.js";
 export type {
   DimensionId,
   Dimension,

--- a/packages/core/test/validation.test.mjs
+++ b/packages/core/test/validation.test.mjs
@@ -116,9 +116,7 @@ test("computeScorecard accepts valid input (regression: validation does not brea
       signalId: "sig-ok",
       questionId: "D1-Q1",
       score: 2,
-      evidence: [
-        { source: "github:repos", data: { count: 3 }, summary: "Three repos found" },
-      ],
+      evidence: [{ source: "github:repos", data: { count: 3 }, summary: "Three repos found" }],
       confidence: 1,
     },
   ];

--- a/packages/core/test/validation.test.mjs
+++ b/packages/core/test/validation.test.mjs
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { computeScorecard, ScoringValidationError } from "../dist/index.js";
+
+const META = { adapterName: "test", target: "test-org" };
+
+test("computeScorecard throws ScoringValidationError when evidence.summary is missing", () => {
+  const malformed = [
+    {
+      signalId: "sig-malformed",
+      questionId: "D1-Q1",
+      score: 2,
+      evidence: [{ source: "github:repos", data: {} }],
+      confidence: 1,
+    },
+  ];
+
+  assert.throws(
+    () => computeScorecard(malformed, META),
+    (err) => {
+      assert.ok(err instanceof ScoringValidationError, "expected ScoringValidationError");
+      assert.match(err.message, /summary/i);
+      assert.ok(err.issues.length >= 1, "should expose Zod issues for diagnostics");
+      return true;
+    }
+  );
+});
+
+test("computeScorecard throws ScoringValidationError when score is not 0/1/2", () => {
+  const malformed = [
+    {
+      signalId: "sig-bad-score",
+      questionId: "D1-Q1",
+      score: 3,
+      evidence: [],
+      confidence: 1,
+    },
+  ];
+
+  assert.throws(
+    () => computeScorecard(malformed, META),
+    (err) => {
+      assert.ok(err instanceof ScoringValidationError);
+      assert.match(err.message, /score/i);
+      return true;
+    }
+  );
+});
+
+test("computeScorecard throws when confidence is outside [0, 1]", () => {
+  const malformed = [
+    {
+      signalId: "sig-bad-confidence",
+      questionId: "D1-Q1",
+      score: 2,
+      evidence: [],
+      confidence: 1.5,
+    },
+  ];
+
+  assert.throws(
+    () => computeScorecard(malformed, META),
+    (err) => {
+      assert.ok(err instanceof ScoringValidationError);
+      assert.match(err.message, /confidence/i);
+      return true;
+    }
+  );
+});
+
+test("computeScorecard throws when evidence.source is missing", () => {
+  const malformed = [
+    {
+      signalId: "sig-bad-source",
+      questionId: "D1-Q1",
+      score: 1,
+      evidence: [{ data: { foo: "bar" }, summary: "ok" }],
+      confidence: 0.9,
+    },
+  ];
+
+  assert.throws(
+    () => computeScorecard(malformed, META),
+    (err) => {
+      assert.ok(err instanceof ScoringValidationError);
+      return true;
+    }
+  );
+});
+
+test("ScoringValidationError.issues is iterable for boundary diagnostics", () => {
+  const malformed = [
+    {
+      signalId: "",
+      questionId: "D1-Q1",
+      score: 5,
+      evidence: [],
+      confidence: -0.1,
+    },
+  ];
+
+  try {
+    computeScorecard(malformed, META);
+    assert.fail("expected throw");
+  } catch (err) {
+    assert.ok(err instanceof ScoringValidationError);
+    // Multiple invariants violated → multiple issues surfaced
+    assert.ok(err.issues.length >= 2);
+  }
+});
+
+test("computeScorecard accepts valid input (regression: validation does not break the happy path)", () => {
+  const valid = [
+    {
+      signalId: "sig-ok",
+      questionId: "D1-Q1",
+      score: 2,
+      evidence: [
+        { source: "github:repos", data: { count: 3 }, summary: "Three repos found" },
+      ],
+      confidence: 1,
+    },
+  ];
+  const result = computeScorecard(valid, META);
+  assert.equal(result.totalScore, 2);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
+      vitest:
+        specifier: 4.1.2
+        version: 4.1.2(@types/node@20.19.37)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(jiti@1.21.7))
 
   packages/core:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: link:../core
       '@anthropic-ai/sdk':
         specifier: ^0.82.0
-        version: 0.82.0
+        version: 0.82.0(zod@4.3.6)
       '@octokit/rest':
         specifier: 22.0.1
         version: 22.0.1
@@ -75,6 +75,10 @@ importers:
         version: 5.9.3
 
   packages/core:
+    dependencies:
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^25.5.2
@@ -224,89 +228,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -376,24 +396,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.14':
     resolution: {integrity: sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.14':
     resolution: {integrity: sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.14':
     resolution: {integrity: sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.14':
     resolution: {integrity: sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==}
@@ -575,36 +599,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -836,41 +866,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1902,24 +1940,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2783,13 +2825,18 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.82.0':
+  '@anthropic-ai/sdk@0.82.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@babel/runtime@7.29.2': {}
 
@@ -5640,3 +5687,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoga-layout@3.2.1: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

Two regression-prevention defects from the audit ([plan](../../../../../../../.claude/plans/do-a-thorhough-analysis-glimmering-shannon.md), section P1 #1 & #3):

1. **Runtime validation at the engine boundary.** Project CLAUDE.md mandates "Use zod for runtime validation at system boundaries" — the rule was being violated for `Evidence` and `SignalResult`. `computeScorecard()` now parses incoming signals through a zod schema and throws a typed error if the shape is wrong (missing `evidence.summary`, score not in {0,1,2}, etc.). Today malformed LLM evidence was silently flowing into the score; now it fails loudly at the boundary.

2. **CLI end-to-end smoke test.** CI today only ran unit tests — exactly why the V1.0/V1.1 regression in commit `8972acf` slipped past. New `packages/cli/test/assess-e2e.test.ts` mocks Octokit and Anthropic, runs the assess command in dry-run, and asserts: exits cleanly, returns all 8 dimensions, totals between 0 and 94, and tier in {AI-Curious, AI-Experimenting, AI-Scaling, AI-Native}.

## Files changed

- `packages/core/src/types/adapter.ts` — zod schemas
- `packages/core/src/errors.ts` — typed `ScoringValidationError`
- `packages/core/src/engine.ts` — validate at `computeScorecard` entry
- `packages/core/test/validation.test.mjs` — boundary failure cases
- `packages/cli/test/assess-e2e.test.ts` — full e2e smoke
- `packages/cli/vitest.config.ts` — wires the new test suite
- `packages/{core,cli}/package.json` + `pnpm-lock.yaml` — adds zod

## Behavior change

`computeScorecard()` may now throw `ScoringValidationError` on malformed input. This is acceptable since the package is pre-1.0 (`version: 0.0.0`) and the throw is at the system boundary per project rules.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm format`
- [x] New `validation.test.mjs` asserts rejection on missing `evidence.summary` and on score outside {0,1,2}
- [x] New `assess-e2e.test.ts` asserts the full CLI flow with mocked Octokit + Anthropic

## Note on authorship

This PR was prepared by the **validation-engineer** teammate as part of an automated team-based remediation for an audit finding. A worktree-isolation issue caused some commits to land on adjacent branches during parallel execution; this branch (`claude/validation-zod-evidence`) is the clean push containing only the validation-engineer's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)