### PR TITLE
feat(ai-inference): add Ollama provider for local LLM inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,19 +232,19 @@ Completed in 8.3s
 
 ## All CLI Options
 
-| Flag                     | Description                                        | Default             |
-| ------------------------ | -------------------------------------------------- | ------------------- |
-| `--github-org <org>`     | GitHub organization to assess                      | —                   |
-| `--github-token <token>` | GitHub PAT (or `GITHUB_TOKEN` env var)             | —                   |
-| `--ai-inference`         | Enable LLM analysis for unmeasurable questions     | off                 |
-| `--provider <name>`      | `anthropic` (cloud) or `ollama` (local)            | `anthropic`         |
-| `--anthropic-key <key>`  | Anthropic API key (or `ANTHROPIC_API_KEY` env var) | —                   |
+| Flag                     | Description                                        | Default                  |
+| ------------------------ | -------------------------------------------------- | ------------------------ |
+| `--github-org <org>`     | GitHub organization to assess                      | —                        |
+| `--github-token <token>` | GitHub PAT (or `GITHUB_TOKEN` env var)             | —                        |
+| `--ai-inference`         | Enable LLM analysis for unmeasurable questions     | off                      |
+| `--provider <name>`      | `anthropic` (cloud) or `ollama` (local)            | `anthropic`              |
+| `--anthropic-key <key>`  | Anthropic API key (or `ANTHROPIC_API_KEY` env var) | —                        |
 | `--ollama-url <url>`     | Ollama base URL (or `OLLAMA_URL` env var)          | `http://localhost:11434` |
-| `--model <model>`        | LLM model to use for inference                     | provider default ¹  |
-| `--output <format>`      | `table` \| `json` \| `markdown`                    | `table`             |
-| `--repos <list>`         | Comma-separated repo names to scope the scan       | all repos           |
-| `--max-repos <n>`        | Maximum repos to scan                              | `50`                |
-| `--dry-run`              | Print config and exit — no API calls               | off                 |
+| `--model <model>`        | LLM model to use for inference                     | provider default ¹       |
+| `--output <format>`      | `table` \| `json` \| `markdown`                    | `table`                  |
+| `--repos <list>`         | Comma-separated repo names to scope the scan       | all repos                |
+| `--max-repos <n>`        | Maximum repos to scan                              | `50`                     |
+| `--dry-run`              | Print config and exit — no API calls               | off                      |
 
 ¹ Default model: `claude-sonnet-4-6` for `--provider anthropic`, `llama3.1` for
 `--provider ollama`. Override with `--model <name>` for either provider.

--- a/README.md
+++ b/README.md
@@ -109,8 +109,12 @@ for the per-question evidence mapping.
 - Node.js ≥ 18
 - A GitHub personal access token with **read-only** org access:
   `repo`, `read:org`, `read:user`
-- _(Optional)_ An Anthropic API key for AI inference on questions that can't be
-  directly measured from repo data
+- _(Optional)_ For AI inference on questions the GitHub API can't measure
+  directly, choose **one** of:
+  - An **Anthropic API key** (cloud, default), or
+  - A local **[Ollama](https://ollama.com)** server — `ollama serve` plus a
+    pulled model (e.g. `ollama pull llama3.1`). No API key, no data leaves
+    your machine.
 
 ### Install
 
@@ -145,12 +149,19 @@ ai-scorecard assess \
   --github-org acme-corp \
   --github-token ghp_xxxxxxxxxxxx
 
-# With AI inference — fills gaps the GitHub API can't answer directly
+# With AI inference (Anthropic, default) — fills gaps the GitHub API can't answer
 ai-scorecard assess \
   --github-org acme-corp \
   --github-token ghp_xxxxxxxxxxxx \
   --ai-inference \
   --anthropic-key sk-ant-xxxxxxxxxxxx
+
+# With AI inference using a LOCAL Ollama server — no API key, no data leaves
+# your machine. Requires `ollama serve` running and `ollama pull llama3.1`.
+ai-scorecard assess \
+  --github-org acme-corp \
+  --github-token ghp_xxxxxxxxxxxx \
+  --ai-inference --provider ollama --model llama3.1
 
 # Scope to specific repos
 ai-scorecard assess \
@@ -226,12 +237,17 @@ Completed in 8.3s
 | `--github-org <org>`     | GitHub organization to assess                      | —                   |
 | `--github-token <token>` | GitHub PAT (or `GITHUB_TOKEN` env var)             | —                   |
 | `--ai-inference`         | Enable LLM analysis for unmeasurable questions     | off                 |
+| `--provider <name>`      | `anthropic` (cloud) or `ollama` (local)            | `anthropic`         |
 | `--anthropic-key <key>`  | Anthropic API key (or `ANTHROPIC_API_KEY` env var) | —                   |
-| `--model <model>`        | LLM model to use for inference                     | `claude-sonnet-4-6` |
+| `--ollama-url <url>`     | Ollama base URL (or `OLLAMA_URL` env var)          | `http://localhost:11434` |
+| `--model <model>`        | LLM model to use for inference                     | provider default ¹  |
 | `--output <format>`      | `table` \| `json` \| `markdown`                    | `table`             |
 | `--repos <list>`         | Comma-separated repo names to scope the scan       | all repos           |
 | `--max-repos <n>`        | Maximum repos to scan                              | `50`                |
 | `--dry-run`              | Print config and exit — no API calls               | off                 |
+
+¹ Default model: `claude-sonnet-4-6` for `--provider anthropic`, `llama3.1` for
+`--provider ollama`. Override with `--model <name>` for either provider.
 
 ---
 

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -15,7 +15,7 @@
     "build": "tsc --project tsconfig.build.json",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "pretest": "tsc --project tsconfig.build.json",
-    "test": "vitest run src/github/__tests__/github-adapter.test.ts src/github/__tests__/agents.test.ts src/github/__tests__/eval.test.ts src/github/__tests__/collector-error.test.ts test/collectors && node --test src/ai-inference/__tests__/ai-inference.test.mjs",
+    "test": "vitest run src/github/__tests__/github-adapter.test.ts src/github/__tests__/agents.test.ts src/github/__tests__/eval.test.ts src/github/__tests__/collector-error.test.ts test/collectors && node --test src/ai-inference/__tests__/ai-inference.test.mjs src/ai-inference/clients/__tests__/ollama-client.test.mjs",
     "lint": "eslint src test --ext .ts",
     "clean": "rm -rf dist"
   },

--- a/packages/adapters/src/ai-inference/__tests__/ai-inference.test.mjs
+++ b/packages/adapters/src/ai-inference/__tests__/ai-inference.test.mjs
@@ -16,11 +16,11 @@ function makeBundle(source = "test-repo", files = []) {
   return { source, files };
 }
 
-/** Build a fake Anthropic-style message response */
-function makeAnthropicResponse(results) {
+/** Build a fake provider-agnostic LLMCompletionResponse from analysis results */
+function makeCompletionResponse(results) {
   return {
-    content: [{ type: "text", text: JSON.stringify(results) }],
-    usage: { input_tokens: 100, output_tokens: 50 },
+    text: JSON.stringify(results),
+    tokenUsage: { inputTokens: 100, outputTokens: 50 },
   };
 }
 
@@ -153,14 +153,12 @@ test("analyze returns SignalResult for each question when LLM responds correctly
     apiKey: "test-key",
   });
 
-  // Monkey-patch the private client to intercept API calls
+  // Monkey-patch the private client to intercept LLM calls
   engine["client"] = {
-    messages: {
-      create: async () => {
-        const response = makeAnthropicResponse(batchResponses[callCount]);
-        callCount++;
-        return response;
-      },
+    complete: async () => {
+      const response = makeCompletionResponse(batchResponses[callCount]);
+      callCount++;
+      return response;
     },
   };
 
@@ -224,12 +222,10 @@ test("analyze fills in missing questions with zero-confidence fallback", async (
   });
 
   engine["client"] = {
-    messages: {
-      create: async () => {
-        const response = makeAnthropicResponse(batchResponses[callCount]);
-        callCount++;
-        return response;
-      },
+    complete: async () => {
+      const response = makeCompletionResponse(batchResponses[callCount]);
+      callCount++;
+      return response;
     },
   };
 
@@ -250,10 +246,8 @@ test("analyze gracefully handles LLM API error", async () => {
 
   // Always throws
   engine["client"] = {
-    messages: {
-      create: async () => {
-        throw new Error("Network error");
-      },
+    complete: async () => {
+      throw new Error("Network error");
     },
   };
 
@@ -274,12 +268,10 @@ test("analyze gracefully handles malformed JSON from LLM", async () => {
   });
 
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [{ type: "text", text: "not valid json {{{" }],
-        usage: { input_tokens: 10, output_tokens: 5 },
-      }),
-    },
+    complete: async () => ({
+      text: "not valid json {{{",
+      tokenUsage: { inputTokens: 10, outputTokens: 5 },
+    }),
   };
 
   const results = await engine.analyze(makeBundle("test-repo"));
@@ -310,27 +302,20 @@ test("analyze handles LLM response wrapped in markdown code fences", async () =>
   });
 
   engine["client"] = {
-    messages: {
-      create: async () => {
-        callCount++;
-        if (callCount === 2) {
-          // architecture batch — wrap in code fences
-          return {
-            content: [
-              {
-                type: "text",
-                text: "```json\n" + JSON.stringify(archResults) + "\n```",
-              },
-            ],
-            usage: { input_tokens: 100, output_tokens: 50 },
-          };
-        }
-        // Other batches return empty arrays
+    complete: async () => {
+      callCount++;
+      if (callCount === 2) {
+        // architecture batch — wrap in code fences
         return {
-          content: [{ type: "text", text: "[]" }],
-          usage: { input_tokens: 10, output_tokens: 5 },
+          text: "```json\n" + JSON.stringify(archResults) + "\n```",
+          tokenUsage: { inputTokens: 100, outputTokens: 50 },
         };
-      },
+      }
+      // Other batches return empty arrays
+      return {
+        text: "[]",
+        tokenUsage: { inputTokens: 10, outputTokens: 5 },
+      };
     },
   };
 
@@ -402,20 +387,13 @@ test("analyze parses JSON array when LLM includes brackets in preamble text", as
 
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [
-          {
-            type: "text",
-            // Brackets appear in the preamble before the actual JSON array
-            text:
-              "Based on rubric [score 0–2] and evidence [see files]:\n" +
-              JSON.stringify([policyResult]),
-          },
-        ],
-        usage: { input_tokens: 50, output_tokens: 20 },
-      }),
-    },
+    complete: async () => ({
+      // Brackets appear in the preamble before the actual JSON array
+      text:
+        "Based on rubric [score 0–2] and evidence [see files]:\n" +
+        JSON.stringify([policyResult]),
+      tokenUsage: { inputTokens: 50, outputTokens: 20 },
+    }),
   };
 
   const results = await engine.analyze(makeBundle("test-repo"));
@@ -431,7 +409,7 @@ test("analyze parses JSON array when LLM includes brackets in preamble text", as
 test("analyze still returns 24 results when all batches fail, with confidence 0", async () => {
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: { create: async () => { throw new Error("API unavailable"); } },
+    complete: async () => { throw new Error("API unavailable"); },
   };
 
   const results = await engine.analyze(makeBundle("test-repo"));
@@ -445,12 +423,10 @@ test("confidence:0 sentinel is preserved through toSignalResult for missing ques
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   // Return an empty array — all questions will get missingResult (confidence 0)
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [{ type: "text", text: "[]" }],
-        usage: { input_tokens: 10, output_tokens: 2 },
-      }),
-    },
+    complete: async () => ({
+      text: "[]",
+      tokenUsage: { inputTokens: 10, outputTokens: 2 },
+    }),
   };
 
   const results = await engine.analyze(makeBundle("test-repo"));
@@ -471,18 +447,11 @@ test("duplicate questionId keeps the higher-confidence entry", async () => {
 
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [
-          {
-            type: "text",
-            // Low-confidence entry appears first, high-confidence second
-            text: JSON.stringify([lowConfidence, highConfidence]),
-          },
-        ],
-        usage: { input_tokens: 50, output_tokens: 20 },
-      }),
-    },
+    complete: async () => ({
+      // Low-confidence entry appears first, high-confidence second
+      text: JSON.stringify([lowConfidence, highConfidence]),
+      tokenUsage: { inputTokens: 50, outputTokens: 20 },
+    }),
   };
 
   const results = await engine.analyze(makeBundle("test-repo"));
@@ -499,14 +468,10 @@ test("duplicate questionId keeps first when it already has higher confidence", a
 
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [
-          { type: "text", text: JSON.stringify([highConfidence, lowConfidence]) },
-        ],
-        usage: { input_tokens: 50, output_tokens: 20 },
-      }),
-    },
+    complete: async () => ({
+      text: JSON.stringify([highConfidence, lowConfidence]),
+      tokenUsage: { inputTokens: 50, outputTokens: 20 },
+    }),
   };
 
   const results = await engine.analyze(makeBundle("test-repo"));
@@ -525,12 +490,10 @@ test("inferred confidence is clamped to [0.3, 0.7] range", async () => {
 
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [{ type: "text", text: JSON.stringify([tooLow]) }],
-        usage: { input_tokens: 10, output_tokens: 5 },
-      }),
-    },
+    complete: async () => ({
+      text: JSON.stringify([tooLow]),
+      tokenUsage: { inputTokens: 10, outputTokens: 5 },
+    }),
   };
 
   const results = await engine.analyze(makeBundle("test-repo"));
@@ -556,12 +519,10 @@ test("SignalResult evidence contains reasoning and evidence_summary", async () =
   });
 
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [{ type: "text", text: JSON.stringify(policyResults) }],
-        usage: { input_tokens: 100, output_tokens: 50 },
-      }),
-    },
+    complete: async () => ({
+      text: JSON.stringify(policyResults),
+      tokenUsage: { inputTokens: 100, outputTokens: 50 },
+    }),
   };
 
   const results = await engine.analyze(makeBundle("test-repo"));
@@ -606,12 +567,10 @@ test("agent analysis: positive case — mature agent definitions with scope and 
 
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [{ type: "text", text: JSON.stringify(agentResults) }],
-        usage: { input_tokens: 200, output_tokens: 80 },
-      }),
-    },
+    complete: async () => ({
+      text: JSON.stringify(agentResults),
+      tokenUsage: { inputTokens: 200, outputTokens: 80 },
+    }),
   };
 
   // Bundle with agent files and commit history metadata
@@ -675,12 +634,10 @@ test("agent analysis: negative case — no agent files, no instruction history",
 
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [{ type: "text", text: JSON.stringify(agentResults) }],
-        usage: { input_tokens: 50, output_tokens: 40 },
-      }),
-    },
+    complete: async () => ({
+      text: JSON.stringify(agentResults),
+      tokenUsage: { inputTokens: 50, outputTokens: 40 },
+    }),
   };
 
   // Bundle with no agent files and no commit history
@@ -742,12 +699,10 @@ test("eval analysis: positive case — LLM-as-judge CI gate, business KPIs, auto
 
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [{ type: "text", text: JSON.stringify(evalResults) }],
-        usage: { input_tokens: 300, output_tokens: 100 },
-      }),
-    },
+    complete: async () => ({
+      text: JSON.stringify(evalResults),
+      tokenUsage: { inputTokens: 300, outputTokens: 100 },
+    }),
   };
 
   // Bundle with CI workflow, eval config, dashboard, regression config, and commit history
@@ -831,12 +786,10 @@ test("eval analysis: negative case — no eval CI, only technical metrics, no re
 
   const engine = new AIInferenceEngine({ provider: "anthropic", apiKey: "test-key" });
   engine["client"] = {
-    messages: {
-      create: async () => ({
-        content: [{ type: "text", text: JSON.stringify(evalResults) }],
-        usage: { input_tokens: 80, output_tokens: 60 },
-      }),
-    },
+    complete: async () => ({
+      text: JSON.stringify(evalResults),
+      tokenUsage: { inputTokens: 80, outputTokens: 60 },
+    }),
   };
 
   // Bundle with no eval-related files and no commit history

--- a/packages/adapters/src/ai-inference/clients/__tests__/ollama-client.test.mjs
+++ b/packages/adapters/src/ai-inference/clients/__tests__/ollama-client.test.mjs
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { OllamaClient } from "../../../../dist/ai-inference/clients/ollama.js";
+
+// ---------------------------------------------------------------------------
+// fetch mock helpers
+// ---------------------------------------------------------------------------
+
+/** Replace globalThis.fetch with a stub. Returns a restore() function and a
+ *  `calls` array the tests can inspect to assert request shape. */
+function stubFetch(handler) {
+  const original = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (input, init) => {
+    calls.push({ input, init });
+    return handler(input, init);
+  };
+  return { calls, restore: () => { globalThis.fetch = original; } };
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("OllamaClient defaults to http://localhost:11434 and posts to /api/chat", async () => {
+  const { calls, restore } = stubFetch(() =>
+    jsonResponse({
+      message: { content: '[{"questionId":"D4-Q22","score":1,"confidence":0.5,"reasoning":"r","evidence_summary":"e"}]' },
+      prompt_eval_count: 42,
+      eval_count: 17,
+    })
+  );
+
+  try {
+    const client = new OllamaClient();
+    const response = await client.complete({
+      model: "llama3.1",
+      maxTokens: 4096,
+      prompt: "analyze this",
+    });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].input, "http://localhost:11434/api/chat");
+    assert.equal(calls[0].init.method, "POST");
+    const body = JSON.parse(calls[0].init.body);
+    assert.equal(body.model, "llama3.1");
+    assert.equal(body.stream, false);
+    assert.equal(body.format, "json");
+    assert.deepEqual(body.messages, [{ role: "user", content: "analyze this" }]);
+    assert.equal(body.options.num_predict, 4096);
+
+    assert.match(response.text, /D4-Q22/);
+    assert.deepEqual(response.tokenUsage, { inputTokens: 42, outputTokens: 17 });
+  } finally {
+    restore();
+  }
+});
+
+test("OllamaClient strips trailing slashes from baseUrl", async () => {
+  const { calls, restore } = stubFetch(() =>
+    jsonResponse({ message: { content: "[]" }, prompt_eval_count: 1, eval_count: 1 })
+  );
+
+  try {
+    const client = new OllamaClient("http://ollama.internal:11434/");
+    await client.complete({ model: "llama3.1", maxTokens: 100, prompt: "x" });
+    assert.equal(calls[0].input, "http://ollama.internal:11434/api/chat");
+  } finally {
+    restore();
+  }
+});
+
+test("OllamaClient throws on non-OK HTTP status so engine fallback can fire", async () => {
+  const { restore } = stubFetch(() => new Response("model not found", { status: 404 }));
+
+  try {
+    const client = new OllamaClient();
+    await assert.rejects(
+      () => client.complete({ model: "missing-model", maxTokens: 100, prompt: "x" }),
+      (err) => err instanceof Error && /404/.test(err.message) && /model not found/.test(err.message)
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("OllamaClient throws when message.content is missing from response", async () => {
+  const { restore } = stubFetch(() =>
+    // Deliberately malformed: no `message` at all
+    jsonResponse({ done: true, prompt_eval_count: 5, eval_count: 0 })
+  );
+
+  try {
+    const client = new OllamaClient();
+    await assert.rejects(
+      () => client.complete({ model: "llama3.1", maxTokens: 100, prompt: "x" }),
+      (err) => err instanceof Error && /missing message\.content/i.test(err.message)
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("OllamaClient omits tokenUsage when prompt_eval_count/eval_count are absent", async () => {
+  const { restore } = stubFetch(() =>
+    jsonResponse({ message: { content: "[]" } })
+  );
+
+  try {
+    const client = new OllamaClient();
+    const response = await client.complete({ model: "llama3.1", maxTokens: 100, prompt: "x" });
+    assert.equal(response.text, "[]");
+    assert.equal(response.tokenUsage, undefined);
+  } finally {
+    restore();
+  }
+});

--- a/packages/adapters/src/ai-inference/clients/__tests__/ollama-client.test.mjs
+++ b/packages/adapters/src/ai-inference/clients/__tests__/ollama-client.test.mjs
@@ -64,6 +64,23 @@ test("OllamaClient defaults to http://localhost:11434 and posts to /api/chat", a
   }
 });
 
+test("OllamaClient falls back to default when baseUrl is an empty string", async () => {
+  // Guards against `??` vs `||` mistake: with `??` an empty string would be
+  // preserved and `fetch("/api/chat")` would throw "Invalid URL". With `||`
+  // we recover the default URL.
+  const { calls, restore } = stubFetch(() =>
+    jsonResponse({ message: { content: "[]" }, prompt_eval_count: 1, eval_count: 1 })
+  );
+
+  try {
+    const client = new OllamaClient("");
+    await client.complete({ model: "llama3.1", maxTokens: 100, prompt: "x" });
+    assert.equal(calls[0].input, "http://localhost:11434/api/chat");
+  } finally {
+    restore();
+  }
+});
+
 test("OllamaClient strips trailing slashes from baseUrl", async () => {
   const { calls, restore } = stubFetch(() =>
     jsonResponse({ message: { content: "[]" }, prompt_eval_count: 1, eval_count: 1 })

--- a/packages/adapters/src/ai-inference/clients/anthropic.ts
+++ b/packages/adapters/src/ai-inference/clients/anthropic.ts
@@ -1,0 +1,40 @@
+/**
+ * Anthropic-backed LLMClient implementation.
+ *
+ * Wraps the @anthropic-ai/sdk Messages API. This is a pure refactor of the
+ * call site that previously lived inline in AIInferenceEngine.runBatch.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { LLMClient, LLMCompletionRequest, LLMCompletionResponse } from "./types.js";
+
+export class AnthropicClient implements LLMClient {
+  private readonly client: Anthropic;
+
+  constructor(apiKey: string) {
+    this.client = new Anthropic({ apiKey });
+  }
+
+  async complete(req: LLMCompletionRequest): Promise<LLMCompletionResponse> {
+    const message = await this.client.messages.create({
+      model: req.model,
+      max_tokens: req.maxTokens,
+      messages: [{ role: "user", content: req.prompt }],
+    });
+
+    // Anthropic responses can contain multiple content blocks (text, tool_use,
+    // etc.). For this engine we only care about the first text block — the
+    // prompts explicitly request a JSON-only response so additional blocks
+    // would indicate a model misbehavior we'd rather surface as parse failure.
+    const textBlock = message.content.find((block) => block.type === "text");
+    const text = textBlock?.type === "text" ? textBlock.text : "";
+
+    return {
+      text,
+      tokenUsage: {
+        inputTokens: message.usage.input_tokens,
+        outputTokens: message.usage.output_tokens,
+      },
+    };
+  }
+}

--- a/packages/adapters/src/ai-inference/clients/factory.ts
+++ b/packages/adapters/src/ai-inference/clients/factory.ts
@@ -21,9 +21,8 @@ export function createLLMClient(config: AIInferenceConfig): LLMClient {
       // assertion keeps this branch a compile-time error if a new provider is
       // added to the union and we forget a case.
       const exhaustive: never = config;
-      throw new Error(
-        `Unknown AI inference provider: ${JSON.stringify((exhaustive as { provider: unknown }).provider)}`
-      );
+      const badProvider = String((exhaustive as { provider: unknown }).provider);
+      throw new Error(`Unknown AI inference provider: ${badProvider}`);
     }
   }
 }

--- a/packages/adapters/src/ai-inference/clients/factory.ts
+++ b/packages/adapters/src/ai-inference/clients/factory.ts
@@ -1,0 +1,19 @@
+/**
+ * Provider factory — turns a discriminated AIInferenceConfig into a concrete
+ * LLMClient. Centralising the switch here keeps AIInferenceEngine free of
+ * provider-specific imports and makes adding a new provider a one-file change.
+ */
+
+import type { AIInferenceConfig } from "../types.js";
+import { AnthropicClient } from "./anthropic.js";
+import { OllamaClient } from "./ollama.js";
+import type { LLMClient } from "./types.js";
+
+export function createLLMClient(config: AIInferenceConfig): LLMClient {
+  switch (config.provider) {
+    case "anthropic":
+      return new AnthropicClient(config.apiKey);
+    case "ollama":
+      return new OllamaClient(config.baseUrl);
+  }
+}

--- a/packages/adapters/src/ai-inference/clients/factory.ts
+++ b/packages/adapters/src/ai-inference/clients/factory.ts
@@ -15,5 +15,15 @@ export function createLLMClient(config: AIInferenceConfig): LLMClient {
       return new AnthropicClient(config.apiKey);
     case "ollama":
       return new OllamaClient(config.baseUrl);
+    default: {
+      // Defense-in-depth for callers that bypass TypeScript (e.g. JS users or
+      // a config-file value that slipped past CLI validation). The exhaustive
+      // assertion keeps this branch a compile-time error if a new provider is
+      // added to the union and we forget a case.
+      const exhaustive: never = config;
+      throw new Error(
+        `Unknown AI inference provider: ${JSON.stringify((exhaustive as { provider: unknown }).provider)}`
+      );
+    }
   }
 }

--- a/packages/adapters/src/ai-inference/clients/ollama.ts
+++ b/packages/adapters/src/ai-inference/clients/ollama.ts
@@ -51,9 +51,7 @@ export class OllamaClient implements LLMClient {
 
     if (!response.ok) {
       const detail = await safeReadText(response);
-      throw new Error(
-        `Ollama request to ${url} failed with status ${response.status}: ${detail}`
-      );
+      throw new Error(`Ollama request to ${url} failed with status ${response.status}: ${detail}`);
     }
 
     const parsed = (await response.json()) as OllamaChatResponse;

--- a/packages/adapters/src/ai-inference/clients/ollama.ts
+++ b/packages/adapters/src/ai-inference/clients/ollama.ts
@@ -1,0 +1,86 @@
+/**
+ * Ollama-backed LLMClient implementation.
+ *
+ * Talks to a local (or remote) Ollama server via its native /api/chat HTTP
+ * endpoint. We use the global `fetch` instead of the `ollama` npm package
+ * because the surface area we need is tiny — adding a dependency would be
+ * premature.
+ *
+ * Why /api/chat (not /api/generate) and not the OpenAI-compatible endpoint:
+ *  - /api/chat takes the same role/content message shape as Anthropic and
+ *    OpenAI, so the prompt format we already build is portable.
+ *  - The native endpoint accepts `format: "json"` which biases the model
+ *    toward valid JSON output. The engine still re-parses defensively via
+ *    extractJsonArray() because local models occasionally emit prose around
+ *    JSON even with the flag set.
+ */
+
+import type { LLMClient, LLMCompletionRequest, LLMCompletionResponse } from "./types.js";
+
+const DEFAULT_BASE_URL = "http://localhost:11434";
+
+interface OllamaChatResponse {
+  message?: { content?: string };
+  prompt_eval_count?: number;
+  eval_count?: number;
+}
+
+export class OllamaClient implements LLMClient {
+  private readonly baseUrl: string;
+
+  constructor(baseUrl?: string) {
+    // Trim trailing slash so we can join paths with a single `/`.
+    this.baseUrl = (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  }
+
+  async complete(req: LLMCompletionRequest): Promise<LLMCompletionResponse> {
+    const url = `${this.baseUrl}/api/chat`;
+    const body = {
+      model: req.model,
+      messages: [{ role: "user", content: req.prompt }],
+      stream: false,
+      format: "json",
+      options: { num_predict: req.maxTokens },
+    };
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const detail = await safeReadText(response);
+      throw new Error(
+        `Ollama request to ${url} failed with status ${response.status}: ${detail}`
+      );
+    }
+
+    const parsed = (await response.json()) as OllamaChatResponse;
+    const text = parsed.message?.content;
+    if (typeof text !== "string") {
+      throw new Error(
+        `Ollama response from ${url} is missing message.content (model: ${req.model})`
+      );
+    }
+
+    // Ollama exposes prompt_eval_count / eval_count when it wasn't a fully
+    // cached response; map them to the canonical input/output token names.
+    const inputTokens = parsed.prompt_eval_count;
+    const outputTokens = parsed.eval_count;
+    const tokenUsage =
+      typeof inputTokens === "number" && typeof outputTokens === "number"
+        ? { inputTokens, outputTokens }
+        : undefined;
+
+    return tokenUsage ? { text, tokenUsage } : { text };
+  }
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return "<unreadable response body>";
+  }
+}

--- a/packages/adapters/src/ai-inference/clients/ollama.ts
+++ b/packages/adapters/src/ai-inference/clients/ollama.ts
@@ -29,8 +29,12 @@ export class OllamaClient implements LLMClient {
   private readonly baseUrl: string;
 
   constructor(baseUrl?: string) {
+    // Use `||` (not `??`) so an empty string from a misconfigured env var
+    // (e.g. `OLLAMA_URL=""`) falls back to the default. With `??` the empty
+    // string is preserved and the later `fetch` call would fail with an
+    // "Invalid URL" error far from the configuration mistake.
     // Trim trailing slash so we can join paths with a single `/`.
-    this.baseUrl = (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+    this.baseUrl = (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, "");
   }
 
   async complete(req: LLMCompletionRequest): Promise<LLMCompletionResponse> {

--- a/packages/adapters/src/ai-inference/clients/types.ts
+++ b/packages/adapters/src/ai-inference/clients/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Provider-agnostic LLM client contract.
+ *
+ * The AI Inference Engine talks to LLM providers through this minimal surface.
+ * Each provider implementation (Anthropic, Ollama, …) wraps its own SDK or
+ * HTTP transport and normalises the response shape so the engine can stay
+ * provider-blind.
+ */
+
+/** A single completion request — one user prompt, one response. */
+export interface LLMCompletionRequest {
+  model: string;
+  maxTokens: number;
+  prompt: string;
+}
+
+/** Normalised response across providers. `tokenUsage` is optional because
+ *  not every provider reports it (e.g., older Ollama versions). */
+export interface LLMCompletionResponse {
+  text: string;
+  tokenUsage?: { inputTokens: number; outputTokens: number };
+}
+
+/** All providers implement this interface. The engine only uses `complete`. */
+export interface LLMClient {
+  complete(req: LLMCompletionRequest): Promise<LLMCompletionResponse>;
+}

--- a/packages/adapters/src/ai-inference/index.ts
+++ b/packages/adapters/src/ai-inference/index.ts
@@ -1,11 +1,12 @@
 /**
  * AI Inference Engine
  *
- * Uses an LLM (Anthropic Claude by default) to analyze repository contents and
- * score questions that cannot be directly measured by the GitHub adapter.
+ * Uses an LLM (Anthropic Claude by default, Ollama for local inference) to
+ * analyze repository contents and score questions that cannot be directly
+ * measured by the GitHub adapter. The engine is provider-blind — all
+ * provider-specific logic lives in clients/* behind the LLMClient interface.
  */
 
-import Anthropic from "@anthropic-ai/sdk";
 import type { SignalResult } from "@ai-scorecard/core";
 import type {
   AIInferenceConfig,
@@ -14,6 +15,8 @@ import type {
   ContentBundle,
   TokenUsage,
 } from "./types.js";
+import type { LLMClient } from "./clients/types.js";
+import { createLLMClient } from "./clients/factory.js";
 import { buildPolicyAnalysisPrompt } from "./prompts/policy-analysis.js";
 import { buildArchitectureAnalysisPrompt } from "./prompts/architecture-analysis.js";
 import { buildDocumentationAnalysisPrompt } from "./prompts/documentation-analysis.js";
@@ -21,8 +24,11 @@ import { buildGovernanceAnalysisPrompt } from "./prompts/governance-analysis.js"
 import { buildAgentAnalysisPrompt } from "./prompts/agent-analysis.js";
 import { buildEvalAnalysisPrompt } from "./prompts/eval-analysis.js";
 
-/** Default model to use when none is specified */
-const DEFAULT_MODEL = "claude-sonnet-4-6";
+/** Default models per provider — applied when config.model is unset. */
+const DEFAULT_MODEL_BY_PROVIDER = {
+  anthropic: "claude-sonnet-4-6",
+  ollama: "llama3.1",
+} as const;
 /** Default max tokens per request */
 const DEFAULT_MAX_TOKENS = 4096;
 /** Signal ID prefix for AI-inferred signals */
@@ -51,12 +57,12 @@ export const AI_INFERENCE_QUESTION_IDS: ReadonlyArray<string> =
  */
 export class AIInferenceEngine {
   private readonly config: AIInferenceConfig;
-  private readonly client: Anthropic | null;
+  private readonly client: LLMClient | null;
 
   constructor(config: AIInferenceConfig) {
     this.config = config;
     // Only instantiate the client when not in dry-run mode
-    this.client = config.dryRun ? null : new Anthropic({ apiKey: config.apiKey });
+    this.client = config.dryRun ? null : createLLMClient(config);
   }
 
   /**
@@ -64,7 +70,7 @@ export class AIInferenceEngine {
    * When dryRun is enabled, logs the analysis plan and returns empty results.
    */
   async analyze(bundle: ContentBundle): Promise<SignalResult[]> {
-    const model = this.config.model ?? DEFAULT_MODEL;
+    const model = this.config.model ?? DEFAULT_MODEL_BY_PROVIDER[this.config.provider];
     const maxTokens = this.config.maxTokens ?? DEFAULT_MAX_TOKENS;
 
     if (this.config.dryRun) {
@@ -101,38 +107,39 @@ export class AIInferenceEngine {
     maxTokens: number
   ): Promise<BatchAnalysisResult> {
     if (!this.client) {
-      throw new Error("Anthropic client is not initialized (dry-run mode)");
+      throw new Error("LLM client is not initialized (dry-run mode)");
     }
 
     let rawText = "";
     let tokenUsage: TokenUsage | undefined;
 
     try {
-      const message = await this.client.messages.create({
-        model,
-        max_tokens: maxTokens,
-        messages: [{ role: "user", content: prompt }],
-      });
+      const response = await this.client.complete({ model, maxTokens, prompt });
+      rawText = response.text;
+      tokenUsage = response.tokenUsage;
 
-      tokenUsage = {
-        inputTokens: message.usage.input_tokens,
-        outputTokens: message.usage.output_tokens,
-      };
-
-      console.log(
-        `[ai-inference] ${analysisType}: ${tokenUsage.inputTokens} input tokens, ` +
-          `${tokenUsage.outputTokens} output tokens`
-      );
-
-      const textBlock = message.content.find((block) => block.type === "text");
-      rawText = textBlock?.type === "text" ? textBlock.text : "";
+      if (tokenUsage) {
+        console.log(
+          `[ai-inference] ${analysisType}: ${tokenUsage.inputTokens} input tokens, ` +
+            `${tokenUsage.outputTokens} output tokens`
+        );
+      } else {
+        // Some providers (e.g., Ollama with cached responses) don't report
+        // token counts. Log the call without numbers so the trace stays useful.
+        console.log(`[ai-inference] ${analysisType}: completed (token usage unavailable)`);
+      }
     } catch (error) {
       console.error(`[ai-inference] Error in ${analysisType} batch:`, error);
       return { analysisType, results: this.fallbackResults(analysisType), error: true };
     }
 
     const { results, error: parseError } = this.parseAnalysisResults(rawText, analysisType);
-    return { analysisType, results, tokenUsage, ...(parseError && { error: true }) };
+    return {
+      analysisType,
+      results,
+      ...(tokenUsage && { tokenUsage }),
+      ...(parseError && { error: true }),
+    };
   }
 
   /**
@@ -245,6 +252,10 @@ export class AIInferenceEngine {
   /** Log the dry-run analysis plan without making API calls */
   private logDryRun(bundle: ContentBundle, model: string, maxTokens: number): void {
     console.log(`[ai-inference] DRY RUN — source: ${bundle.source}`);
+    console.log(`[ai-inference] Provider: ${this.config.provider}`);
+    if (this.config.provider === "ollama") {
+      console.log(`[ai-inference] Ollama URL: ${this.config.baseUrl ?? "http://localhost:11434"}`);
+    }
     console.log(`[ai-inference] Model: ${model}, maxTokens: ${maxTokens}`);
     console.log(`[ai-inference] Files: ${bundle.files.length} file(s)`);
     for (const file of bundle.files) {

--- a/packages/adapters/src/ai-inference/types.ts
+++ b/packages/adapters/src/ai-inference/types.ts
@@ -1,12 +1,15 @@
 /**
  * AI-specific types for the AI Inference Engine.
+ *
+ * AIInferenceConfig is a discriminated union over `provider`. Each provider
+ * carries only the fields it needs — TypeScript prevents mixing (e.g., setting
+ * an `apiKey` when using Ollama, which doesn't authenticate).
  */
 
-/** Configuration for the AI Inference Engine */
-export interface AIInferenceConfig {
-  /** LLM provider (start with Anthropic Claude) */
+/** Anthropic-backed inference (default). Requires an API key. */
+export interface AnthropicInferenceConfig {
   provider: "anthropic";
-  /** API key for the LLM provider */
+  /** API key for the Anthropic API */
   apiKey: string;
   /** Model to use (default: claude-sonnet-4-6) */
   model?: string;
@@ -15,6 +18,22 @@ export interface AIInferenceConfig {
   /** When true, shows what would be analyzed without making API calls */
   dryRun?: boolean;
 }
+
+/** Ollama-backed inference (local or self-hosted). No API key required. */
+export interface OllamaInferenceConfig {
+  provider: "ollama";
+  /** Base URL of the Ollama server (default: http://localhost:11434) */
+  baseUrl?: string;
+  /** Model to use (default: llama3.1) */
+  model?: string;
+  /** Maximum tokens per analysis request */
+  maxTokens?: number;
+  /** When true, shows what would be analyzed without making API calls */
+  dryRun?: boolean;
+}
+
+/** Configuration for the AI Inference Engine. */
+export type AIInferenceConfig = AnthropicInferenceConfig | OllamaInferenceConfig;
 
 /** A bundle of files and metadata to be analyzed by the AI inference engine */
 export interface ContentBundle {

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -7,11 +7,18 @@ export type { Adapter } from "@ai-scorecard/core";
 export { AIInferenceEngine, AI_INFERENCE_QUESTION_IDS } from "./ai-inference/index.js";
 export type {
   AIInferenceConfig,
+  AnthropicInferenceConfig,
+  OllamaInferenceConfig,
   ContentBundle,
   AIAnalysisResult,
   TokenUsage,
   BatchAnalysisResult,
 } from "./ai-inference/types.js";
+export type {
+  LLMClient,
+  LLMCompletionRequest,
+  LLMCompletionResponse,
+} from "./ai-inference/clients/types.js";
 export { GitHubAdapter } from "./github/index.js";
 export type { GitHubAdapterConfig } from "./github/config.js";
 export type { GitHubCollectResult } from "./github/index.js";

--- a/packages/cli/src/commands/assess.ts
+++ b/packages/cli/src/commands/assess.ts
@@ -90,11 +90,21 @@ export async function runAssess(options: AssessOptions): Promise<void> {
     console.error(chalk.red("Error: --github-token is required (or set GITHUB_TOKEN env var)."));
     process.exit(1);
   }
-  // Provider-specific validation: only Anthropic requires an API key. Ollama
-  // talks to a local (or self-hosted) server and is unauthenticated by default.
+  // Provider validation. The CLI flag is constrained via .choices(...), but a
+  // config file's `ai.provider` value bypasses that and is read as a raw
+  // string. Validate explicitly so an invalid value (typo, future provider
+  // name) fails loudly instead of silently dispatching to Ollama.
   if (options.aiInference) {
-    const provider = options.provider ?? "anthropic";
-    if (provider === "anthropic" && !options.anthropicKey) {
+    const rawProvider = options.provider ?? "anthropic";
+    if (rawProvider !== "anthropic" && rawProvider !== "ollama") {
+      console.error(
+        chalk.red(
+          `Error: unknown provider "${rawProvider}". Supported providers: anthropic, ollama.`
+        )
+      );
+      process.exit(1);
+    }
+    if (rawProvider === "anthropic" && !options.anthropicKey) {
       console.error(
         chalk.red(
           "Error: --anthropic-key is required when --ai-inference is enabled with --provider anthropic."
@@ -155,9 +165,7 @@ export async function runAssess(options: AssessOptions): Promise<void> {
     options.aiInference && (provider === "ollama" || Boolean(options.anthropicKey));
 
   if (options.aiInference && canRunInference) {
-    const aiSpinner = ora(
-      `Running AI inference analysis (${provider})…`
-    ).start();
+    const aiSpinner = ora(`Running AI inference analysis (${provider})…`).start();
     try {
       const engine = new AIInferenceEngine(
         provider === "anthropic"

--- a/packages/cli/src/commands/assess.ts
+++ b/packages/cli/src/commands/assess.ts
@@ -95,7 +95,11 @@ export async function runAssess(options: AssessOptions): Promise<void> {
   // string. Validate explicitly so an invalid value (typo, future provider
   // name) fails loudly instead of silently dispatching to Ollama.
   if (options.aiInference) {
-    const rawProvider = options.provider ?? "anthropic";
+    // Widen to string so the unknown-provider branch isn't narrowed to `never`
+    // (the eslint restrict-template-expressions rule rejects never in template
+    // literals; keeping it as string lets us interpolate the bad value back to
+    // the user verbatim).
+    const rawProvider: string = options.provider ?? "anthropic";
     if (rawProvider !== "anthropic" && rawProvider !== "ollama") {
       console.error(
         chalk.red(

--- a/packages/cli/src/commands/assess.ts
+++ b/packages/cli/src/commands/assess.ts
@@ -18,7 +18,11 @@ export interface AssessOptions {
   githubOrg?: string;
   githubToken?: string;
   aiInference?: boolean;
+  /** "anthropic" (default) or "ollama" */
+  provider?: "anthropic" | "ollama";
   anthropicKey?: string;
+  /** Base URL for Ollama (default: http://localhost:11434) */
+  ollamaUrl?: string;
   output?: "table" | "json" | "markdown";
   repos?: string;
   dryRun?: boolean;
@@ -39,8 +43,15 @@ function dryRun(options: AssessOptions): void {
   console.log(`  Max repos:     ${options.maxRepos ?? 50}`);
   console.log(`  AI Inference:  ${options.aiInference ? "enabled" : "disabled"}`);
   if (options.aiInference) {
-    console.log(`  Anthropic Key: ${options.anthropicKey ? "***" : "(not set)"}`);
-    console.log(`  Model:         ${options.model ?? "claude-sonnet-4-6"}`);
+    const provider = options.provider ?? "anthropic";
+    console.log(`  Provider:      ${provider}`);
+    if (provider === "anthropic") {
+      console.log(`  Anthropic Key: ${options.anthropicKey ? "***" : "(not set)"}`);
+      console.log(`  Model:         ${options.model ?? "claude-sonnet-4-6"}`);
+    } else {
+      console.log(`  Ollama URL:    ${options.ollamaUrl ?? "http://localhost:11434"}`);
+      console.log(`  Model:         ${options.model ?? "llama3.1"}`);
+    }
   }
   console.log(`  Output format: ${options.output ?? "table"}`);
   console.log(
@@ -79,9 +90,18 @@ export async function runAssess(options: AssessOptions): Promise<void> {
     console.error(chalk.red("Error: --github-token is required (or set GITHUB_TOKEN env var)."));
     process.exit(1);
   }
-  if (options.aiInference && !options.anthropicKey) {
-    console.error(chalk.red("Error: --anthropic-key is required when --ai-inference is enabled."));
-    process.exit(1);
+  // Provider-specific validation: only Anthropic requires an API key. Ollama
+  // talks to a local (or self-hosted) server and is unauthenticated by default.
+  if (options.aiInference) {
+    const provider = options.provider ?? "anthropic";
+    if (provider === "anthropic" && !options.anthropicKey) {
+      console.error(
+        chalk.red(
+          "Error: --anthropic-key is required when --ai-inference is enabled with --provider anthropic."
+        )
+      );
+      process.exit(1);
+    }
   }
 
   const startTime = Date.now();
@@ -130,14 +150,28 @@ export async function runAssess(options: AssessOptions): Promise<void> {
   // ── Step 3: AI Inference (optional) ───────────────────────────────────────
   let aiSignals: SignalResult[] = [];
 
-  if (options.aiInference && options.anthropicKey) {
-    const aiSpinner = ora("Running AI inference analysis…").start();
+  const provider = options.provider ?? "anthropic";
+  const canRunInference =
+    options.aiInference && (provider === "ollama" || Boolean(options.anthropicKey));
+
+  if (options.aiInference && canRunInference) {
+    const aiSpinner = ora(
+      `Running AI inference analysis (${provider})…`
+    ).start();
     try {
-      const engine = new AIInferenceEngine({
-        provider: "anthropic",
-        apiKey: options.anthropicKey,
-        ...(options.model !== undefined ? { model: options.model } : {}),
-      });
+      const engine = new AIInferenceEngine(
+        provider === "anthropic"
+          ? {
+              provider: "anthropic",
+              apiKey: options.anthropicKey as string,
+              ...(options.model !== undefined ? { model: options.model } : {}),
+            }
+          : {
+              provider: "ollama",
+              ...(options.ollamaUrl !== undefined ? { baseUrl: options.ollamaUrl } : {}),
+              ...(options.model !== undefined ? { model: options.model } : {}),
+            }
+      );
 
       const bundle: ContentBundle = {
         source: `github:${org}`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,11 +38,24 @@ program
     "GitHub personal access token",
     process.env["GITHUB_TOKEN"] ?? config.github?.token
   )
-  .option("--ai-inference", "Enable AI inference analysis (requires Anthropic key)")
+  .option("--ai-inference", "Enable AI inference analysis")
+  .addOption(
+    new Option(
+      "--provider <provider>",
+      "AI inference provider: anthropic (default) or ollama (local)"
+    )
+      .choices(["anthropic", "ollama"])
+      .default(config.ai?.provider ?? "anthropic")
+  )
   .option(
     "--anthropic-key <key>",
-    "Anthropic API key for AI inference",
+    "Anthropic API key (required when --provider anthropic)",
     process.env["ANTHROPIC_API_KEY"] ?? config.ai?.apiKey
+  )
+  .option(
+    "--ollama-url <url>",
+    "Ollama base URL (default: http://localhost:11434)",
+    process.env["OLLAMA_URL"] ?? config.ai?.baseUrl
   )
   .option("--model <model>", "AI model to use for inference", config.ai?.model)
   .addOption(
@@ -69,7 +82,9 @@ program
       githubOrg?: string;
       githubToken?: string;
       aiInference?: boolean;
+      provider?: "anthropic" | "ollama";
       anthropicKey?: string;
+      ollamaUrl?: string;
       model?: string;
       output?: "table" | "json" | "markdown";
       repos?: string;
@@ -80,7 +95,9 @@ program
         ...(opts.githubOrg !== undefined ? { githubOrg: opts.githubOrg } : {}),
         ...(opts.githubToken !== undefined ? { githubToken: opts.githubToken } : {}),
         ...(opts.aiInference !== undefined ? { aiInference: opts.aiInference } : {}),
+        ...(opts.provider !== undefined ? { provider: opts.provider } : {}),
         ...(opts.anthropicKey !== undefined ? { anthropicKey: opts.anthropicKey } : {}),
+        ...(opts.ollamaUrl !== undefined ? { ollamaUrl: opts.ollamaUrl } : {}),
         ...(opts.model !== undefined ? { model: opts.model } : {}),
         output: opts.output ?? "table",
         ...(opts.repos !== undefined ? { repos: opts.repos } : {}),

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -17,9 +17,14 @@ export interface CliConfig {
     maxRepos?: number;
   };
   ai?: {
+    /** "anthropic" or "ollama" */
     provider?: string;
+    /** Anthropic API key (only meaningful when provider=anthropic) */
     apiKey?: string;
+    /** Model name; default depends on provider */
     model?: string;
+    /** Ollama base URL (only meaningful when provider=ollama) */
+    baseUrl?: string;
   };
   output?: "table" | "json" | "markdown";
 }
@@ -50,6 +55,7 @@ export function loadConfig(): CliConfig {
       ai: {
         ...(cwdConfig.ai.provider !== undefined && { provider: cwdConfig.ai.provider }),
         ...(cwdConfig.ai.model !== undefined && { model: cwdConfig.ai.model }),
+        ...(cwdConfig.ai.baseUrl !== undefined && { baseUrl: cwdConfig.ai.baseUrl }),
       },
     }),
   };


### PR DESCRIPTION
## Summary

- Adds **Ollama** as an alternative AI inference provider so assessments can run fully local — no API key, no data leaves the machine. Anthropic Claude remains the default.
- Introduces a small `LLMClient` provider abstraction so the engine is no longer hardcoded to a single SDK; future providers become a one-file change in `clients/`.
- Existing public surface (`AIInferenceEngine.analyze()`, prompts, scoring) is unchanged.

## Why

The target audience — engineering leaders at mid-size companies — often can't or won't send proprietary repo content to a third-party LLM. Adding a local Ollama path unlocks that use case while also enabling cost-free CI runs.

## What changed

**Adapters package**
- `clients/types.ts` — new `LLMClient` interface (`complete(req): Promise<response>`).
- `clients/anthropic.ts` — wraps `@anthropic-ai/sdk`. Pure refactor of the prior inline call.
- `clients/ollama.ts` — talks to `/api/chat` via native `fetch` with `format: "json"`. No new dependency.
- `clients/factory.ts` — `createLLMClient(config)` switch.
- `types.ts` — `AIInferenceConfig` is now a discriminated union (`anthropic | ollama`). TypeScript prevents mixing fields like `apiKey` into the Ollama branch.
- `index.ts` — `AIInferenceEngine` uses the factory and calls `client.complete(...)`. Per-provider model defaults: `claude-sonnet-4-6` / `llama3.1`.

**CLI package**
- New flags: `--provider <anthropic|ollama>`, `--ollama-url <url>`. `OLLAMA_URL` env var supported.
- Validation is provider-aware: `--anthropic-key` is only required for `--provider anthropic`.
- Dry-run output prints provider + URL.
- `CliConfig.ai.baseUrl` added so config files can pin an Ollama endpoint.

**Tests**
- Existing 24 `ai-inference` tests rewired to mock the new `complete()` shape instead of Anthropic's `messages.create`. No semantic test changes.
- New `clients/__tests__/ollama-client.test.mjs` (5 tests) stubs `globalThis.fetch` and covers: happy path + request body shape, baseUrl trailing-slash normalization, HTTP error path, malformed response, missing `prompt_eval_count`/`eval_count`.

**Docs**
- README Quickstart gains an "Ollama (local)" recipe.
- All CLI Options table adds `--provider`, `--ollama-url`, and a footnote on per-provider model defaults.

## Reviewer notes

- **JSON parsing safeguards left intact.** `extractJsonArray()` is still in the engine; Ollama's `format: "json"` helps but local models can still emit prose preambles, so the defensive parser earns its keep.
- **Failure semantics unchanged.** Any `complete()` rejection bubbles up to the same `try/catch` that previously wrapped Anthropic errors; failed batches still return zero-confidence fallbacks with `error: true`.
- **`exactOptionalPropertyTypes: true`** required `tokenUsage` to be omitted (not `undefined`) when the provider doesn't report it. Handled with `...(tokenUsage && { tokenUsage })` conditional spread, matching the codebase's existing style.

## Test plan

- [x] `pnpm --filter @ai-scorecard/core --filter @ai-scorecard/adapters --filter @ai-scorecard/cli typecheck` — all green
- [x] `pnpm --filter @ai-scorecard/core --filter @ai-scorecard/adapters --filter @ai-scorecard/cli test` — 38 core + 191 adapter (162 vitest + 29 node-test) + 19 CLI tests pass
- [x] Dry-run with `--provider ollama --model llama3.1` prints the new provider/URL/model lines
- [x] Dry-run default (anthropic) is unchanged
- [x] Validation: `--ai-inference` without `--anthropic-key` exits 1 with a helpful error
- [x] Validation: `--ai-inference --provider ollama` proceeds without an API key
- [ ] End-to-end against a live Ollama (`ollama serve` + `ollama pull llama3.1`) — left for local verification before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)